### PR TITLE
html: confusão no fechamento de tags

### DIFF
--- a/inf/app/views/projects/_projects_table.html.erb
+++ b/inf/app/views/projects/_projects_table.html.erb
@@ -74,11 +74,11 @@
                     <div class="cut-text">
                         <i class="icon-tag"></i>
                         <%= project.tags.collect{|t| t.tag_text}.join(" · ") %>
-                  </smaller>
+                    </div>
                 <% else %>
                   <br>
                 <% end %>
-              </div>
+              </smaller>
             </a>
           </div>          
         </td>


### PR DESCRIPTION
O fechamento das tags html não estavam na ordem correta.
