### PR TITLE
Ajusta #wrap padding-top automaticamente em telas pequenas

### DIFF
--- a/inf/app/assets/javascripts/application.js
+++ b/inf/app/assets/javascripts/application.js
@@ -40,6 +40,11 @@ $(function () {
 	$('[rel=popover]').popover({placement:'bottom',html:true});
 });
 
+// Adjust #wrap padding-top when navbar grows vertically (on small screns)
+$(window).resize(function() {
+  $("#wrap").css("padding-top", $("header").height() + 3);
+});
+
 // Function used within forms for deleting uploaded files.
 // Remember to: (1) create a hidden field holding a boolean value
 // 				(2) pass into this function the ID of the field of the previous step


### PR DESCRIPTION
O site não está rodando bem em dispositivos com telas pequenas (celulares, principalmente). Por causa da pequena largura máxima, o a altura do menu acaba aumentando e cobrindo o resto do conteúdo:
![screen shot 2014-04-05 at 20 28 51](https://cloud.githubusercontent.com/assets/607762/2796236/aa885706-cc09-11e3-8d9c-b3d9345f305a.png)
Creio que o ideal seja tornar o menu responsivo, incluindo aquele 'botão' toggle do Bootstrap. Enquanto não se resolve isso, meu commit corrige via javascript:
![screen shot 2014-04-05 at 20 29 06](https://cloud.githubusercontent.com/assets/607762/2796253/e55befd2-cc09-11e3-91a8-20d5ee34b307.png)
